### PR TITLE
Generated build.sbt: don't duplicate version information

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,7 +7,7 @@ version := "$version$"
 scalaVersion := "2.10.2"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.10" % "1.9.2" % "test"
+  "org.scalatest" %% "scalatest" % "1.9.2" % "test"
 )
 
 initialCommands := "import $organization$.$name;format="lower,word"$._"


### PR DESCRIPTION
Instead of having 2.10 twice, use %%.
