### PR TITLE
Update scalatest scala version to 2.11

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,7 +7,7 @@ version := "$version$"
 scalaVersion := "2.11.5"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.10" % "2.2.1" % "test" withSources() withJavadoc(),
+  "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test" withSources() withJavadoc(),
   "org.scalacheck" %% "scalacheck" % "1.12.1" % "test" withSources() withJavadoc()
 )
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,7 +7,7 @@ version := "$version$"
 scalaVersion := "2.11.5"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test" withSources() withJavadoc(),
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test" withSources() withJavadoc(),
   "org.scalacheck" %% "scalacheck" % "1.12.1" % "test" withSources() withJavadoc()
 )
 


### PR DESCRIPTION
I was unable to execute the unit tests (`java.lang.NoClassDefFoundError: scala/collection/GenTraversableOnce$class` thrown) until I made this change.

I also considered adding a `projects/build.properties` file that would set the sbt version, but determined that this didn't make a difference in solving the aforementioned error.